### PR TITLE
update to use .NET8 for unittests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -200,7 +200,7 @@ jobs:
 
   package:
     needs: [build-windows-x64, build-linux-x64, build-windows-arm64]
-    runs-on: ubuntu-22.04 # note: nuget is not available in Ubuntu 24.04 any more by default, we should migrate to "dotnet pack" instead of loose .nuspec file I guess
+    runs-on: ubuntu-22.04 # note: nuget is not available in Ubuntu 24.04 any more by default, we should migrate to "dotnet pack" instead of a loose .nuspec file I guess
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -200,7 +200,7 @@ jobs:
 
   package:
     needs: [build-windows-x64, build-linux-x64, build-windows-arm64]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # note: nuget is not available in Ubuntu 24.04 any more by default, we should migrate to "dotnet pack" instead of loose .nuspec file I guess
     steps:
       - uses: actions/checkout@v4
 
@@ -211,9 +211,6 @@ jobs:
 
       - name: Package NuGet
         run: |
-          sudo apt-get update         # as of Ubuntu24-04, Nuget is not installed by default
-          sudo apt-get install nuget  # -> https://github.com/actions/runner-images/issues/10631
-
           # We organize the native binaries in a way that they can be packed into a NuGet package. We follow this convention for the folder structure:
           # runtimes/<RID>/native, where <RID> is the Runtime Identifier for the target platform.
           mkdir nuget-packaging

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -211,6 +211,9 @@ jobs:
 
       - name: Package NuGet
         run: |
+          sudo apt-get update         # as of Ubuntu24-04, Nuget is not installed by default
+          sudo apt-get install nuget  # -> https://github.com/actions/runner-images/issues/10631
+
           # We organize the native binaries in a way that they can be packed into a NuGet package. We follow this convention for the folder structure:
           # runtimes/<RID>/native, where <RID> is the Runtime Identifier for the target platform.
           mkdir nuget-packaging

--- a/dotnet/ImgDoc2Net_UnitTests/ImgDoc2Net_UnitTests.csproj
+++ b/dotnet/ImgDoc2Net_UnitTests/ImgDoc2Net_UnitTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/dotnet/ImgDoc2Playground_NetCore/ImgDoc2Playground_NetCore.csproj
+++ b/dotnet/ImgDoc2Playground_NetCore/ImgDoc2Playground_NetCore.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Build failed because .NET7 is not supported any more on the GH-runners.


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

by CI/CD-build

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
